### PR TITLE
Allow modification of xml existing on the system

### DIFF
--- a/lib/puppet/type/xmlfile.rb
+++ b/lib/puppet/type/xmlfile.rb
@@ -179,6 +179,14 @@ Puppet::Type.newtype(:xmlfile) do
     end
   end
 
+  newparam(:use_existing_file) do
+    desc <<-'EOT'
+      Should a exising file in the filestystem be updated or should we start with a blank document? Defaults to false.
+    EOT
+    
+    defaultto false
+  end
+
   # Generates content
   def should_content # Ape the name from property::should
     return @should_content if @should_content # Only do this ONCE
@@ -190,6 +198,9 @@ Puppet::Type.newtype(:xmlfile) do
       content = self[:content]
     elsif ! self[:source].nil?
       content = Puppet::FileServing::Content.indirection.find(self[:source], :environment => catalog.environment).content
+    elsif self[:use_existing_file] && File.exist?(self[:path])
+      xmlFile = File.open(self[:path])
+      content = xmlFile.read
     else
       content = String.new # No content so we start with a base string.
     end


### PR DESCRIPTION
I would like to use this module to update existing xml files on Windows nodes. 

Is there some way to define that today?

Otherwise to achieve this I have added the flag use_existing_file to the xmlfile resource. This property is only needed if we want to be backward compatible , otherwise this could be the default behaviour if no source is given.
